### PR TITLE
Adds hover styles to modifier class

### DIFF
--- a/src/scss/components/_buttons.scss
+++ b/src/scss/components/_buttons.scss
@@ -49,6 +49,13 @@
 .dl-button--on-blue {
   @include govuk-style-button($button-text-colour: govuk-colour("blue"), $button-colour: govuk-colour("white"), $button-shadow-colour: govuk-colour("black"));
   font-weight: bold;
+
+  &:link,
+  &:visited {
+    &:hover {
+      color: darken(govuk-colour("blue"), 5%);
+    }
+  }
 }
 
 // Allows you to align an anchor next to the button


### PR DESCRIPTION
Adds hover styles to modifier class counter specificity of default hover styles.

Currently when hovered the button text is white which makes it unreadable:

![image](https://user-images.githubusercontent.com/57055/116258193-a3b84080-a76c-11eb-914e-647254233734.png)

This change fixes that. Bug can be found on the [design system landing page](https://digital-land.github.io/design-system/)